### PR TITLE
Make description nullable

### DIFF
--- a/src/Entity.php
+++ b/src/Entity.php
@@ -28,9 +28,9 @@ class Entity
   public $aliases = [];
 
   /**
-   * @var string Entity description
+   * @var string|null Entity description
    */
-  public string $description;
+  public ?string $description;
 
   public Collection $properties;
 


### PR DESCRIPTION
When fetching something, the description can be null. However, this isn't reflected in the entity.

Example ( https://www.wikidata.org/wiki/Q777211 ):
```$this->wikidata->get('Q777211');```

results in:
```
Cannot assign null to property Wikidata\Entity::$description of type string  
```

This PR aims to fix that.